### PR TITLE
fix: Correct Android AAB build workflow

### DIFF
--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -11,25 +11,25 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Set up Java 17
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set up Java
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: '21'
 
       - name: Install Android SDK
         uses: android-actions/setup-android@v2
 
-      - name: Create local.properties
-        run: |
-          echo "sdk.dir=$ANDROID_HOME" > local.properties
-
-      - name: Grant Gradle permission
-        run: chmod +x ./android/gradlew
-
       - name: Build AAB
-        working-directory: android
-        run: ./gradlew bundleRelease
+        run: npm run android:release
 
       - name: Upload AAB as artifact
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "android:debug": "npm run build && npx cap sync android && cd android && ./gradlew assembleDebug",
+    "android:release": "npm run build && npx cap sync android && cd android && ./gradlew bundleRelease",
     "test": "vitest"
   },
   "dependencies": {


### PR DESCRIPTION
The AAB build was failing because the workflow was missing the necessary steps to build the web app and synchronize it with the native Android project.

This commit fixes the build by:
1. Adding a new `android:release` npm script to `package.json` that encapsulates all the necessary build steps (`npm run build`, `npx cap sync`, `gradlew bundleRelease`).
2. Simplifying the `.github/workflows/build-aab.yml` file to use this new script, making it consistent with the working APK build process.