### PR TITLE
feat: calculate moonrise and moonset

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -6,7 +6,7 @@ import { TidePoint, TideForecast } from '@/services/tide/types';
 import { LocationData } from '@/types/locationTypes';
 import { SavedLocation } from './LocationSelector';
 import { formatApiDate } from '@/utils/dateTimeUtils';
-import { calculateMoonPhase } from '@/utils/lunarUtils';
+import { calculateMoonPhase, calculateMoonTimes } from '@/utils/lunarUtils';
 
 interface MainContentProps {
   error: string | null;
@@ -38,12 +38,15 @@ export default function MainContent({
   onGetStarted
 }: MainContentProps) {
   const { phase, illumination } = calculateMoonPhase(new Date(currentDate));
+  const lat = currentLocation?.lat ?? 41.4353;
+  const lng = currentLocation?.lng ?? -71.4616;
+  const { moonrise, moonset } = calculateMoonTimes(new Date(currentDate), lat, lng);
 
   const moonPhaseData = {
     phase,
     illumination,
-    moonrise: "18:42",
-    moonset: "07:15",
+    moonrise,
+    moonset,
     date: formatApiDate(currentDate)
   };
 

--- a/src/components/MoonData.tsx
+++ b/src/components/MoonData.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { formatTimeToAmPm } from '@/utils/dateTimeUtils';
+import { formatIsoToAmPm } from '@/utils/dateTimeUtils';
 import { calculateMoonPhase } from '@/utils/lunarUtils';
 
 type MoonDataProps = {
@@ -59,11 +59,11 @@ const MoonData = ({ illumination, moonrise, moonset }: MoonDataProps) => {
       </div>
       <div className="flex items-center justify-between py-1">
         <span className="text-muted-foreground">Moonrise</span>
-        <span className="font-semibold">{formatTimeToAmPm(moonrise)}</span>
+        <span className="font-semibold">{formatIsoToAmPm(moonrise)}</span>
       </div>
       <div className="flex items-center justify-between py-1">
         <span className="text-muted-foreground">Moonset</span>
-        <span className="font-semibold">{formatTimeToAmPm(moonset)}</span>
+        <span className="font-semibold">{formatIsoToAmPm(moonset)}</span>
       </div>
       <div className="flex items-center justify-between py-1">
         <span className="text-muted-foreground">Next Phase</span>

--- a/tests/lunarUtils.test.ts
+++ b/tests/lunarUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateMoonPhase } from '../src/utils/lunarUtils';
+import { calculateMoonPhase, calculateMoonTimes } from '../src/utils/lunarUtils';
 
 // Test a date mid-cycle far from reference to ensure accuracy
 // July 16, 2025 should be Waning Gibbous according to trusted ephemeris
@@ -15,5 +15,14 @@ describe('calculateMoonPhase', () => {
     const date = new Date('2026-07-15T00:00:00Z');
     const result = calculateMoonPhase(date);
     expect(result.phase).toBe('New Moon');
+  });
+});
+
+describe('calculateMoonTimes', () => {
+  it('computes moonrise and moonset for Newport on July 16, 2025', () => {
+    const date = new Date('2025-07-16T00:00:00Z');
+    const { moonrise, moonset } = calculateMoonTimes(date, 41.4353, -71.4616);
+    expect(moonrise).toBe('2025-07-16T16:42:34');
+    expect(moonset).toBe('2025-07-16T04:02:44');
   });
 });


### PR DESCRIPTION
## Summary
- compute moonrise and moonset for current location and date
- show moonrise/moonset in MoonPhase and MoonData
- test moon time calculations for a known date and location

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f374df608832dbbba436005ce8315