### PR TITLE
Fix moonrise and moonset time parsing

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -5,7 +5,7 @@ import WeeklyForecast from '@/components/WeeklyForecast';
 import { TidePoint, TideForecast } from '@/services/tide/types';
 import { LocationData } from '@/types/locationTypes';
 import { SavedLocation } from './LocationSelector';
-import { formatApiDate } from '@/utils/dateTimeUtils';
+import { formatApiDate, parseIsoAsLocal } from '@/utils/dateTimeUtils';
 import { calculateMoonPhase, calculateMoonTimes } from '@/utils/lunarUtils';
 
 interface MainContentProps {
@@ -37,10 +37,11 @@ export default function MainContent({
   banner,
   onGetStarted
 }: MainContentProps) {
-  const { phase, illumination } = calculateMoonPhase(new Date(currentDate));
+  const dateObj = parseIsoAsLocal(`${currentDate}T00:00:00`);
+  const { phase, illumination } = calculateMoonPhase(dateObj);
   const lat = currentLocation?.lat ?? 41.4353;
   const lng = currentLocation?.lng ?? -71.4616;
-  const { moonrise, moonset } = calculateMoonTimes(new Date(currentDate), lat, lng);
+  const { moonrise, moonset } = calculateMoonTimes(dateObj, lat, lng);
 
   const moonPhaseData = {
     phase,

--- a/tests/lunarUtils.test.ts
+++ b/tests/lunarUtils.test.ts
@@ -1,18 +1,19 @@
 import { describe, it, expect } from 'vitest';
 import { calculateMoonPhase, calculateMoonTimes } from '../src/utils/lunarUtils';
+import { parseIsoAsLocal } from '../src/utils/dateTimeUtils';
 
 // Test a date mid-cycle far from reference to ensure accuracy
 // July 16, 2025 should be Waning Gibbous according to trusted ephemeris
 
 describe('calculateMoonPhase', () => {
   it('returns Waning Gibbous for July 16, 2025', () => {
-    const date = new Date('2025-07-16T00:00:00Z');
+    const date = parseIsoAsLocal('2025-07-16T00:00:00');
     const result = calculateMoonPhase(date);
     expect(result.phase).toBe('Waning Gibbous');
   });
 
   it('handles new moon in 2026 without drift', () => {
-    const date = new Date('2026-07-15T00:00:00Z');
+    const date = parseIsoAsLocal('2026-07-15T00:00:00');
     const result = calculateMoonPhase(date);
     expect(result.phase).toBe('New Moon');
   });
@@ -20,7 +21,7 @@ describe('calculateMoonPhase', () => {
 
 describe('calculateMoonTimes', () => {
   it('computes moonrise and moonset for Newport on July 16, 2025', () => {
-    const date = new Date('2025-07-16T00:00:00Z');
+    const date = parseIsoAsLocal('2025-07-16T00:00:00');
     const { moonrise, moonset } = calculateMoonTimes(date, 41.4353, -71.4616);
     expect(moonrise).toBe('2025-07-16T16:42:34');
     expect(moonset).toBe('2025-07-16T04:02:44');


### PR DESCRIPTION
## Summary
- parse API dates as local midnight before computing moon phase or rise/set
- adjust lunar utility tests to parse dates in local time

## Testing
- `bun test`
- `bun run lint` *(fails: Cannot find package '/workspace/moontide-bundle/node_modules/eslint-plugin-react-hooks/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_689f4421dd60832dbcc6236ca0ac73a0