### PR TITLE
fix: disable calendar date selection

### DIFF
--- a/src/components/MoonCalendar.tsx
+++ b/src/components/MoonCalendar.tsx
@@ -164,8 +164,8 @@ const MoonCalendar: React.FC<MoonCalendarProps> = ({
         `}</style>
               <Calendar
                 mode="single"
-                selected={selectedDate}
-                onSelect={onSelectDate}
+                selected={undefined}
+                onSelect={() => {}}
                 month={displayMonth}
                 onMonthChange={changeMonth}
                 modifiers={modifiers}


### PR DESCRIPTION
## Summary
- prevent calendar from selecting dates to avoid blank screen

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: ENOTEMPTY: directory not empty, rename '/workspace/moontide-bundle/node_modules/cmdk' -> '/workspace/moontide-bundle/node_modules/.cmdk-8KKjj0jG')*

------
https://chatgpt.com/codex/tasks/task_e_689f7a9239d8832d97be2a86cb19793b