### PR TITLE
Fix calendar width overflow

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -229,10 +229,11 @@ function Calendar({
     nav_button_next: "absolute right-1",
     table: "w-full border-collapse space-y-1",
     head_row: "flex",
-    head_cell: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+    head_cell:
+      "text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem]",
     row: "flex w-full mt-2",
     cell:
-      "h-9 w-9 text-center text-sm p-0 relative " +
+      "text-center text-sm p-0 relative flex-1 aspect-square " +
       "[&:has([aria-selected].day-range-end)]:rounded-r-md " +
       "[&:has([aria-selected].day-outside)]:bg-accent/50 " +
       "[&:has([aria-selected])]:bg-accent " +
@@ -241,7 +242,7 @@ function Calendar({
       "focus-within:relative focus-within:z-20",
     day: cn(
       buttonVariants({ variant: "ghost" }),
-      "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
+      "w-full h-full p-0 font-normal aria-selected:opacity-100"
     ),
     day_range_end: "day-range-end",
     day_selected:


### PR DESCRIPTION
## Summary
- make calendar days and headers flex to avoid horizontal cutoff

## Testing
- `node node_modules/vitest/vitest.mjs run`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_68a34b55fbec832d9ab330e48b35a563