### PR TITLE
fix: correct privacy and terms links

### DIFF
--- a/src/components/settings/SettingsList.tsx
+++ b/src/components/settings/SettingsList.tsx
@@ -9,13 +9,13 @@ const SettingsList = () => {
         icon={FileText}
         title="Privacy Policy"
         subtitle="Read how we handle data"
-        onClick={() => window.open('https://moontide.site/privacy', '_blank')}
+        onClick={() => window.open('https://moontide.site/privacy.html', '_blank')}
       />
       <SettingsItem
         icon={FileText}
         title="Terms of Service"
         subtitle="Review our terms"
-        onClick={() => window.open('https://moontide.site/terms', '_blank')}
+        onClick={() => window.open('https://moontide.site/terms.html', '_blank')}
       />
       <SettingsItem
         icon={Mail}


### PR DESCRIPTION
## Summary
- point privacy policy and terms of service links to `privacy.html` and `terms.html`

## Testing
- `bun test` *(fails: expect(received).toBe(expected))*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a37a635c0c832dbffb5e4ddc1b5df6