### PR TITLE
feat: add solar flow graph

### DIFF
--- a/src/components/SolarFlow.tsx
+++ b/src/components/SolarFlow.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { getSolarSeries, getCurrentDayIndexJuneShifted } from '@/utils/solarFlow';
+import { NatureEventRule } from '@/types/nature';
+import { evaluateRules } from '@/utils/natureEval';
+
+interface SolarFlowProps {
+  lat: number;
+  lng: number;
+  date: Date;
+  height?: number;
+  className?: string;
+  showMonths?: boolean;
+  natureRules?: NatureEventRule[];
+  isPro?: boolean;
+}
+
+const SolarFlow: React.FC<SolarFlowProps> = ({
+  lat,
+  lng,
+  date,
+  height = 80,
+  className,
+  showMonths = true,
+  natureRules = [],
+  isPro = false,
+}) => {
+  const series = React.useMemo(
+    () => getSolarSeries(lat, lng, date.getFullYear()),
+    [lat, lng, date]
+  );
+  const currentIndex = React.useMemo(
+    () => getCurrentDayIndexJuneShifted(date),
+    [date]
+  );
+  const days = series.juneShiftedDays;
+  const total = days.length;
+  const points = React.useMemo(
+    () => days.map((d, i) => `${i},${24 - d.daylightHr}`).join(' '),
+    [days]
+  );
+
+  React.useMemo(() => evaluateRules(series, natureRules), [series, natureRules]);
+
+  const gridIndices = [
+    series.indices.summer,
+    series.indices.autumn,
+    series.indices.winter,
+    series.indices.spring,
+  ];
+
+  const monthTicks = [
+    { label: 'Jun', idx: 0 },
+    { label: 'Sep', idx: getCurrentDayIndexJuneShifted(new Date(date.getFullYear(), 8, 1)) },
+    { label: 'Dec', idx: getCurrentDayIndexJuneShifted(new Date(date.getFullYear(), 11, 1)) },
+    { label: 'Mar', idx: getCurrentDayIndexJuneShifted(new Date(date.getFullYear() + 1, 2, 1)) },
+    { label: 'Jun', idx: total },
+  ];
+
+  return (
+    <div className={cn('w-full', className)}>
+      <div className="relative w-full" style={{ height }}>
+        <svg
+          viewBox={`0 0 ${total} 24`}
+          preserveAspectRatio="none"
+          className="absolute inset-0 w-full h-full"
+        >
+          {gridIndices.map((g, i) => (
+            <line
+              key={i}
+              x1={g}
+              x2={g}
+              y1={0}
+              y2={24}
+              className="stroke-muted-foreground/30"
+              strokeWidth={0.5}
+            />
+          ))}
+          {monthTicks.map((m, i) => (
+            <line
+              key={`tick-${i}`}
+              x1={m.idx}
+              x2={m.idx}
+              y1={23.5}
+              y2={24}
+              className="stroke-muted-foreground/30"
+              strokeWidth={0.5}
+            />
+          ))}
+          <polyline
+            points={points}
+            className="fill-none stroke-yellow-400"
+            strokeWidth={1}
+          />
+          <line
+            x1={currentIndex}
+            x2={currentIndex}
+            y1={0}
+            y2={24}
+            className="stroke-red-500"
+            strokeWidth={0.5}
+          />
+        </svg>
+        <div
+          className="absolute -top-4 text-[0.625rem] text-red-500"
+          style={{
+            left: `${(currentIndex / total) * 100}%`,
+            transform: 'translateX(-50%)',
+          }}
+        >
+          Now
+        </div>
+      </div>
+      {showMonths && (
+        <div className="relative mt-1 h-4 text-[0.625rem] text-muted-foreground">
+          {monthTicks.map((m, i) => (
+            <span
+              key={i}
+              className="absolute"
+              style={{
+                left: `${(m.idx / total) * 100}%`,
+                transform: 'translateX(-50%)',
+              }}
+            >
+              {m.label}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SolarFlow;
+

--- a/src/components/SunCard.tsx
+++ b/src/components/SunCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { calculateSolarTimes } from '@/utils/solarUtils';
 import { formatSignedDuration } from '../utils/time';
+import SolarFlow from './SolarFlow';
 
 interface SunCardProps {
   lat: number;
@@ -47,33 +48,39 @@ const SunCard: React.FC<SunCardProps> = ({ lat, lng, date, zipCode }) => {
           <span className="text-gray-400">Sunrise</span>
           <span className="font-semibold">{sunTimes.sunrise}</span>
         </div>
-      <div className="flex justify-between">
-        <span className="text-gray-400">Sunset</span>
-        <span className="font-semibold">{sunTimes.sunset}</span>
-      </div>
-      <div className="flex justify-between">
-        <span className="text-gray-400">Daylight</span>
-        <span className="font-semibold text-yellow-400">{sunTimes.daylight}</span>
-      </div>
-      <div className="flex justify-between">
-        <span className="text-gray-400">Darkness</span>
-        <span className="font-semibold text-blue-400">{sunTimes.darkness}</span>
-      </div>
-      <div className="flex justify-between">
-        <span className="text-gray-400">Change</span>
-        <span className={`font-semibold ${gettingLonger ? 'text-lime-400' : gettingShorter ? 'text-red-400' : 'text-gray-300'}`}>{sunTimes.changeFromPrevious}</span>
-      </div>
-      <div className="mt-1 text-sm leading-tight">
-        <div className="flex items-center whitespace-nowrap gap-1 text-[0.688rem] sm:text-xs md:text-sm text-gray-400">
-          Since {refLabelDate} ({refSeasonFull} Solstice)
+        <div className="flex justify-between">
+          <span className="text-gray-400">Sunset</span>
+          <span className="font-semibold">{sunTimes.sunset}</span>
         </div>
-        <div className={deltaMins < 0 ? 'text-red-400' : 'text-lime-400'}>
-          Daylight {formatSignedDuration(deltaMins)}
+        <div className="flex justify-between">
+          <span className="text-gray-400">Daylight</span>
+          <span className="font-semibold text-yellow-400">{sunTimes.daylight}</span>
         </div>
+        <div className="flex justify-between">
+          <span className="text-gray-400">Darkness</span>
+          <span className="font-semibold text-blue-400">{sunTimes.darkness}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-gray-400">Change</span>
+          <span className={`font-semibold ${gettingLonger ? 'text-lime-400' : gettingShorter ? 'text-red-400' : 'text-gray-300'}`}>
+            {sunTimes.changeFromPrevious}
+          </span>
+        </div>
+        <div className="mt-1 text-sm leading-tight">
+          <div className="flex items-center whitespace-nowrap gap-1 text-[0.688rem] sm:text-xs md:text-sm text-gray-400">
+            Since {refLabelDate} ({refSeasonFull} Solstice)
+          </div>
+          <div className={deltaMins < 0 ? 'text-red-400' : 'text-lime-400'}>
+            Daylight {formatSignedDuration(deltaMins)}
+          </div>
+        </div>
+      </div>
+      <div className="mt-3">
+        <SolarFlow lat={lat} lng={lng} date={date} />
       </div>
     </div>
-  </div>
   );
 };
 
 export default SunCard;
+

--- a/src/types/nature.ts
+++ b/src/types/nature.ts
@@ -1,0 +1,9 @@
+export type TriggerKind = 'photoperiod';
+
+export interface NatureEventRule {
+  id: string;
+  trigger: TriggerKind;
+  threshold: number; // daylight hours threshold
+  label: string;
+}
+

--- a/src/utils/natureEval.ts
+++ b/src/utils/natureEval.ts
@@ -1,0 +1,15 @@
+import { NatureEventRule } from '@/types/nature';
+import type { SolarSeries } from './solarFlow';
+
+export interface NatureEvalResult {
+  bands: Array<{ start: number; end: number; label: string }>;
+  markers: Array<{ index: number; label: string }>;
+}
+
+export const evaluateRules = (
+  _series: SolarSeries,
+  _rules: NatureEventRule[]
+): NatureEvalResult => {
+  return { bands: [], markers: [] };
+};
+

--- a/src/utils/solarFlow.ts
+++ b/src/utils/solarFlow.ts
@@ -1,0 +1,100 @@
+import { calculateSolarTimes } from './solarUtils';
+
+export type SolarDay = {
+  date: Date;
+  daylightHr: number;
+};
+
+export type SolarSeries = {
+  year: number;
+  days: SolarDay[];
+  juneShiftedDays: SolarDay[];
+  indices: {
+    summer: number;
+    winter: number;
+    spring: number;
+    autumn: number;
+  };
+};
+
+const cache = new Map<string, SolarSeries>();
+
+const dayMs = 1000 * 60 * 60 * 24;
+
+export const getSolarSeries = (lat: number, lng: number, year: number): SolarSeries => {
+  const key = `${year}:${lat.toFixed(2)}:${lng.toFixed(2)}`;
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const days: SolarDay[] = [];
+  const start = new Date(year, 0, 1);
+  start.setHours(12, 0, 0, 0);
+
+  for (let d = new Date(start); d.getFullYear() === year; d.setTime(d.getTime() + dayMs)) {
+    const times = calculateSolarTimes(new Date(d), lat, lng);
+    days.push({ date: new Date(d), daylightHr: times.daylightMinutes / 60 });
+  }
+
+  let summerIndex = 0;
+  let winterIndex = 0;
+  let springEquinoxIndex = 0;
+  let autumnEquinoxIndex = 0;
+
+  let max = -Infinity;
+  let min = Infinity;
+  let prev = days[0]?.daylightHr ?? 0;
+
+  for (let i = 0; i < days.length; i++) {
+    const h = days[i].daylightHr;
+    if (h > max) {
+      max = h;
+      summerIndex = i;
+    }
+    if (h < min) {
+      min = h;
+      winterIndex = i;
+    }
+    const month = days[i].date.getMonth();
+    if (!springEquinoxIndex && month >= 2 && month <= 3 && prev < 12 && h >= 12) {
+      springEquinoxIndex = i;
+    }
+    if (!autumnEquinoxIndex && month >= 8 && month <= 9 && prev > 12 && h <= 12) {
+      autumnEquinoxIndex = i;
+    }
+    prev = h;
+  }
+
+  const total = days.length;
+  const juneShiftedDays = days.slice(summerIndex).concat(days.slice(0, summerIndex));
+  const shift = (idx: number) => (idx - summerIndex + total) % total;
+
+  const series: SolarSeries = {
+    year,
+    days,
+    juneShiftedDays,
+    indices: {
+      summer: 0,
+      winter: shift(winterIndex),
+      spring: shift(springEquinoxIndex),
+      autumn: shift(autumnEquinoxIndex),
+    },
+  };
+
+  cache.set(key, series);
+  return series;
+};
+
+export const getCurrentDayIndexJuneShifted = (date: Date): number => {
+  const year = date.getFullYear();
+  const june21 = new Date(year, 5, 21);
+  june21.setHours(0, 0, 0, 0);
+  let diff = Math.floor((date.getTime() - june21.getTime()) / dayMs);
+  if (diff < 0) {
+    const prevJune21 = new Date(year - 1, 5, 21);
+    prevJune21.setHours(0, 0, 0, 0);
+    const daysInYear = Math.round((june21.getTime() - prevJune21.getTime()) / dayMs);
+    diff += daysInYear;
+  }
+  return diff;
+};
+


### PR DESCRIPTION
## Summary
- add solarFlow utility to compute annual daylight series and June-shifted indices
- scaffold neutral nature evaluation engine and types
- append SolarFlow graph inside SunCard showing daylight wave and current day marker

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a46c256350832d9323610c1ab99b77