### PR TITLE
feat: refine solar flow visualization

### DIFF
--- a/src/components/SolarFlow.tsx
+++ b/src/components/SolarFlow.tsx
@@ -29,12 +29,12 @@ const SolarFlow: React.FC<SolarFlowProps> = ({
     () => getSolarSeries(lat, lng, date.getFullYear()),
     [lat, lng, date]
   );
-  const currentIndex = React.useMemo(
-    () => getCurrentDayIndexJuneShifted(date),
-    [date]
-  );
   const days = series.juneShiftedDays;
   const total = days.length;
+  const currentIndex = React.useMemo(
+    () => getCurrentDayIndexJuneShifted(series, date),
+    [series, date]
+  );
   const points = React.useMemo(
     () => days.map((d, i) => `${i},${24 - d.daylightHr}`).join(' '),
     [days]
@@ -42,77 +42,97 @@ const SolarFlow: React.FC<SolarFlowProps> = ({
 
   React.useMemo(() => evaluateRules(series, natureRules), [series, natureRules]);
 
-  const gridIndices = [
-    series.indices.summer,
-    series.indices.autumn,
-    series.indices.winter,
-    series.indices.spring,
-  ];
-
   const monthTicks = [
     { label: 'Jun', idx: 0 },
-    { label: 'Sep', idx: getCurrentDayIndexJuneShifted(new Date(date.getFullYear(), 8, 1)) },
-    { label: 'Dec', idx: getCurrentDayIndexJuneShifted(new Date(date.getFullYear(), 11, 1)) },
-    { label: 'Mar', idx: getCurrentDayIndexJuneShifted(new Date(date.getFullYear() + 1, 2, 1)) },
+    { label: 'Sep', idx: series.indices.autumn },
+    { label: 'Dec', idx: series.indices.winter },
+    { label: 'Mar', idx: series.indices.spring },
     { label: 'Jun', idx: total },
+  ];
+  const gridIndices = monthTicks.map((m) => m.idx);
+
+  const calcY = React.useCallback(
+    (idx: number) => {
+      const i0 = Math.floor(idx);
+      const i1 = (i0 + 1) % total;
+      const t = idx - i0;
+      const hr =
+        days[i0].daylightHr * (1 - t) + days[i1].daylightHr * t;
+      return 24 - hr;
+    },
+    [days, total]
+  );
+
+  const guideYs = [
+    calcY(series.indices.summer),
+    12,
+    calcY(series.indices.winter),
   ];
 
   return (
     <div className={cn('w-full', className)}>
-      <div className="relative w-full" style={{ height }}>
-        <svg
-          viewBox={`0 0 ${total} 24`}
-          preserveAspectRatio="none"
-          className="absolute inset-0 w-full h-full"
-        >
-          {gridIndices.map((g, i) => (
+      <div className="relative w-full">
+        <div className="relative w-full overflow-hidden" style={{ height }}>
+          <svg
+            viewBox={`0 0 ${total} 24`}
+            preserveAspectRatio="none"
+            className="absolute inset-0 h-full w-full"
+          >
+            {gridIndices.map((g, i) => (
+              <line
+                key={`v-${i}`}
+                x1={g}
+                x2={g}
+                y1={0}
+                y2={24}
+                className="stroke-muted-foreground/10"
+                strokeWidth={0.5}
+                strokeDasharray="2 2"
+              />
+            ))}
+            {guideYs.map((y, i) => (
+              <line
+                key={`h-${i}`}
+                x1={0}
+                x2={total}
+                y1={y}
+                y2={y}
+                className="stroke-muted-foreground/10"
+                strokeWidth={0.5}
+                strokeDasharray="2 2"
+              />
+            ))}
+            <polyline
+              points={points}
+              className="fill-none stroke-yellow-400"
+              strokeWidth={1}
+            />
             <line
-              key={i}
-              x1={g}
-              x2={g}
+              x1={currentIndex}
+              x2={currentIndex}
               y1={0}
               y2={24}
-              className="stroke-muted-foreground/30"
+              className="stroke-destructive"
               strokeWidth={0.5}
             />
-          ))}
-          {monthTicks.map((m, i) => (
-            <line
-              key={`tick-${i}`}
-              x1={m.idx}
-              x2={m.idx}
-              y1={23.5}
-              y2={24}
-              className="stroke-muted-foreground/30"
-              strokeWidth={0.5}
-            />
-          ))}
-          <polyline
-            points={points}
-            className="fill-none stroke-yellow-400"
-            strokeWidth={1}
-          />
-          <line
-            x1={currentIndex}
-            x2={currentIndex}
-            y1={0}
-            y2={24}
-            className="stroke-red-500"
-            strokeWidth={0.5}
-          />
-        </svg>
-        <div
-          className="absolute -top-4 text-[0.625rem] text-red-500"
-          style={{
-            left: `${(currentIndex / total) * 100}%`,
-            transform: 'translateX(-50%)',
-          }}
-        >
-          Now
+          </svg>
+        </div>
+        <div className="pointer-events-none absolute inset-0 overflow-visible">
+          <div
+            className="absolute text-[0.625rem] text-destructive"
+            style={{
+              left: `${(currentIndex / total) * 100}%`,
+              top: 0,
+              transform: 'translate(-50%, -100%)',
+              marginTop: '-6px',
+            }}
+          >
+            Now
+          </div>
         </div>
       </div>
       {showMonths && (
-        <div className="relative mt-1 h-4 text-[0.625rem] text-muted-foreground">
+        <div className="relative mt-1 h-4 text-[0.625rem] text-foreground">
           {monthTicks.map((m, i) => (
             <span
               key={i}


### PR DESCRIPTION
## Summary
- revamp SolarFlow to float the "Now" label above chart and draw faint seasonal guides
- derive month ticks and solstice/equinox indices directly from daylight data

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4885b3790832d9081180296f9c5d5