### PR TITLE
feat: enhance solar flow chart

### DIFF
--- a/src/components/SolarFlow.tsx
+++ b/src/components/SolarFlow.tsx
@@ -68,6 +68,11 @@ const SolarFlow: React.FC<SolarFlowProps> = ({
     12,
     calcY(series.indices.winter),
   ];
+  const guideLabels = [
+    'Summer Solstice (max)',
+    'Equinox (~12h)',
+    'Winter Solstice (min)',
+  ];
 
   return (
     <div className={cn('w-full', className)}>
@@ -114,6 +119,7 @@ const SolarFlow: React.FC<SolarFlowProps> = ({
               y2={24}
               className="stroke-destructive"
               strokeWidth={0.5}
+              strokeDasharray="4 4"
             />
           </svg>
         </div>
@@ -129,6 +135,20 @@ const SolarFlow: React.FC<SolarFlowProps> = ({
           >
             Now
           </div>
+          {guideYs.map((y, i) => (
+            <div
+              key={`t-${i}`}
+              className="absolute text-[0.625rem] text-muted-foreground"
+              style={{
+                left: 0,
+                top: `${(y / 24) * 100}%`,
+                transform: 'translate(-105%, -50%)',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {guideLabels[i]}
+            </div>
+          ))}
         </div>
       </div>
       {showMonths && (

--- a/src/components/SunCard.tsx
+++ b/src/components/SunCard.tsx
@@ -76,6 +76,7 @@ const SunCard: React.FC<SunCardProps> = ({ lat, lng, date, zipCode }) => {
         </div>
       </div>
       <div className="mt-3">
+        <h3 className="mb-1 text-xs font-semibold">Solar Flow</h3>
         <SolarFlow lat={lat} lng={lng} date={date} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show solstice and equinox labels on solar flow graph
- display dashed "Now" indicator line
- add "Solar Flow" heading to sun card

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a493089850832d8484189486f07dad