### PR TITLE
feat: move Solar Flow title to card header

### DIFF
--- a/src/components/SunCard.tsx
+++ b/src/components/SunCard.tsx
@@ -40,6 +40,11 @@ const SunCard: React.FC<SunCardProps> = ({ lat, lng, date, zipCode }) => {
 
   return (
     <div className="flex flex-col gap-y-2 text-sm">
+      {/* Title row */}
+      <div className="text-base sm:text-lg font-semibold tracking-tight mb-1">
+        Solar Flow
+      </div>
+
       {zipCode && (
         <div className="text-xs text-muted-foreground">ZIP {zipCode}</div>
       )}
@@ -76,7 +81,6 @@ const SunCard: React.FC<SunCardProps> = ({ lat, lng, date, zipCode }) => {
         </div>
       </div>
       <div className="mt-3">
-        <h3 className="mb-1 text-xs font-semibold">Solar Flow</h3>
         <SolarFlow lat={lat} lng={lng} date={date} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show "Solar Flow" as card heading above ZIP line
- drop in-card title so graph renders alone

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a1f165b0832db1f2062fdb5b3132