### PR TITLE
Refactor SolarFlow guide rendering

### DIFF
--- a/src/components/SolarFlow.tsx
+++ b/src/components/SolarFlow.tsx
@@ -63,15 +63,10 @@ const SolarFlow: React.FC<SolarFlowProps> = ({
     [days, total]
   );
 
-  const guideYs = [
-    calcY(series.indices.summer),
-    12,
-    calcY(series.indices.winter),
-  ];
-  const guideLabels = [
-    'Summer Solstice (max)',
-    'Equinox (~12h)',
-    'Winter Solstice (min)',
+  const guides = [
+    { y: calcY(series.indices.summer), label: 'Summer Solstice (max)' },
+    { y: 12, label: 'Equinox (~12h)' },
+    { y: calcY(series.indices.winter), label: 'Winter Solstice (min)' },
   ];
 
   return (
@@ -95,13 +90,13 @@ const SolarFlow: React.FC<SolarFlowProps> = ({
                 strokeDasharray="2 2"
               />
             ))}
-            {guideYs.map((y, i) => (
+            {guides.map((g, i) => (
               <line
                 key={`h-${i}`}
                 x1={0}
                 x2={total}
-                y1={y}
-                y2={y}
+                y1={g.y}
+                y2={g.y}
                 className="stroke-muted-foreground/10"
                 strokeWidth={0.5}
                 strokeDasharray="2 2"
@@ -135,18 +130,18 @@ const SolarFlow: React.FC<SolarFlowProps> = ({
           >
             Now
           </div>
-          {guideYs.map((y, i) => (
+          {guides.map((g, i) => (
             <div
               key={`t-${i}`}
               className="absolute text-[0.625rem] text-muted-foreground"
               style={{
                 left: 0,
-                top: `${(y / 24) * 100}%`,
+                top: `${(g.y / 24) * 100}%`,
                 transform: 'translate(-105%, -50%)',
                 whiteSpace: 'nowrap',
               }}
             >
-              {guideLabels[i]}
+              {g.label}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- consolidate guide labels and positions into a single `guides` array in `SolarFlow`
- render guide lines and labels from the unified data structure

## Testing
- `node node_modules/vitest/vitest.mjs run` *(fails: Cannot find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68a4b1a53160832d900fca917899d5ca