### PR TITLE
Refine solar info branding and metrics

### DIFF
--- a/src/components/SolarInfo.tsx
+++ b/src/components/SolarInfo.tsx
@@ -1,6 +1,5 @@
 
 import React from 'react';
-import { Sunrise, Sunset, Clock, TrendingUp, TrendingDown } from 'lucide-react';
 import { SolarTimes } from '@/utils/solarUtils';
 
 type SolarInfoProps = {
@@ -19,52 +18,64 @@ const SolarInfo = ({ solarTimes, zipCode }: SolarInfoProps) => {
           Sunrise/Sunset for ZIP {zipCode}
         </div>
       )}
-      <div className="grid grid-cols-2 sm:grid-cols-5 gap-y-3 text-xs text-center">
+      <div className="grid grid-cols-2 sm:grid-cols-5 gap-y-1 text-xs text-center">
         {/* Sunrise */}
-        <div className="flex flex-col items-center">
-          <Sunrise className="h-4 w-4 text-orange-400 mb-1" />
+        <div className="flex flex-col">
           <span className="text-muted-foreground">Sunrise</span>
           <span className="font-semibold">{solarTimes.sunrise}</span>
         </div>
 
         {/* Sunset */}
-        <div className="flex flex-col items-center">
-          <Sunset className="h-4 w-4 text-red-400 mb-1" />
+        <div className="flex flex-col">
           <span className="text-muted-foreground">Sunset</span>
           <span className="font-semibold">{solarTimes.sunset}</span>
         </div>
 
         {/* Total Daylight */}
-        <div className="flex flex-col items-center">
-          <Clock className="h-4 w-4 text-yellow-400 mb-1" />
+        <div className="flex flex-col">
           <span className="text-muted-foreground">Daylight</span>
           <span className="font-semibold text-yellow-400">{solarTimes.daylight}</span>
         </div>
 
         {/* Total Darkness */}
-        <div className="flex flex-col items-center">
-          <Clock className="h-4 w-4 text-blue-400 mb-1" />
+        <div className="flex flex-col">
           <span className="text-muted-foreground">Darkness</span>
           <span className="font-semibold text-blue-400">{solarTimes.darkness}</span>
         </div>
 
         {/* Change from Previous Day */}
         {solarTimes.changeFromPrevious && (
-          <div className="flex flex-col items-center">
-            {isGettingLonger && <TrendingUp className="h-4 w-4 text-green-400 mb-1" />}
-            {isGettingShorter && <TrendingDown className="h-4 w-4 text-red-400 mb-1" />}
-            {!isGettingLonger && !isGettingShorter && <Clock className="h-4 w-4 text-muted-foreground mb-1" />}
+          <div className="flex flex-col">
             <span className="text-muted-foreground">Change</span>
-            <span className={`font-semibold ${
-              isGettingLonger ? 'text-green-400' :
-              isGettingShorter ? 'text-red-400' :
-              'text-muted-foreground'
-            }`}>
+            <span
+              className={`font-semibold ${
+                isGettingLonger
+                  ? 'text-green-400'
+                  : isGettingShorter
+                  ? 'text-red-400'
+                  : 'text-muted-foreground'
+              }`}
+            >
               {solarTimes.changeFromPrevious}
             </span>
           </div>
         )}
       </div>
+
+      {solarTimes.changeSinceSolstice && (
+        <div className="mt-3 text-center text-xs">
+          <div className="text-muted-foreground">Since Jun 21 (Summer Solstice)</div>
+          <div
+            className={`font-semibold ${
+              solarTimes.changeSinceSolstice.startsWith('-')
+                ? 'text-red-400'
+                : 'text-green-400'
+            }`}
+          >
+            Daylight {solarTimes.changeSinceSolstice}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/SunCard.tsx
+++ b/src/components/SunCard.tsx
@@ -7,13 +7,13 @@ interface SunCardProps {
   lat: number;
   lng: number;
   date: Date;
-  /** Optional ZIP code to show above the chart */
+  /** Optional ZIP code to show in the info block */
   zipCode?: string;
 }
 
 /**
  * SunCard
- * Displays metadata (e.g., ZIP, sunrise/sunset etc. if you add it) and the SolarFlow chart.
+ * Displays metadata (e.g., sunrise/sunset etc.) and the SolarFlow chart.
  * Layout matches other cards (rounded, padded, dark surface).
  */
 const SunCard: React.FC<SunCardProps> = ({ lat, lng, date, zipCode }) => {
@@ -22,8 +22,6 @@ const SunCard: React.FC<SunCardProps> = ({ lat, lng, date, zipCode }) => {
     () => calculateSolarTimes(date, lat, lng),
     [date, lat, lng]
   );
-
-  const zipText = zipCode ? `ZIP ${zipCode}` : undefined;
 
   return (
     <div
@@ -43,19 +41,8 @@ const SunCard: React.FC<SunCardProps> = ({ lat, lng, date, zipCode }) => {
             marginBottom: 2,
           }}
         >
-          Solar Flow
+          SolarFlow
         </div>
-        {zipText ? (
-          <div
-            style={{
-              fontSize: 13,
-              color: "rgba(255,255,255,0.6)",
-              marginBottom: 6,
-            }}
-          >
-            {zipText}
-          </div>
-        ) : null}
       </div>
 
       {/* Sunrise/Sunset data block */}

--- a/src/utils/solarUtils.ts
+++ b/src/utils/solarUtils.ts
@@ -7,6 +7,7 @@ export type SolarTimes = {
   daylightMinutes: number; // Total daylight in minutes for comparison
   darkness: string;
   changeFromPrevious?: string; // Change from previous day
+  changeSinceSolstice?: string; // Difference from summer solstice
 };
 
 export type SolarEvent = {
@@ -93,6 +94,19 @@ export const calculateSolarTimes = (
     changeFromPrevious = `${diff}m shorter`;
   }
 
+  // Difference in daylight from the summer solstice (June 21)
+  const solsticeDate = new Date(date.getFullYear(), 5, 21);
+  const solstice = getTimes(solsticeDate, lat, lng);
+  const diffSolstice = daylightMinutes - Math.round(solstice.daylightMinutes);
+  let changeSinceSolstice = '';
+  if (diffSolstice !== 0) {
+    const sign = diffSolstice > 0 ? '+' : '-';
+    const abs = Math.abs(diffSolstice);
+    changeSinceSolstice = `${sign}${Math.floor(abs / 60)}h ${abs % 60}m`;
+  } else {
+    changeSinceSolstice = '0m';
+  }
+
   return {
     sunrise: format(current.sunriseDate),
     sunset: format(current.sunsetDate),
@@ -100,6 +114,7 @@ export const calculateSolarTimes = (
     daylightMinutes,
     darkness,
     changeFromPrevious,
+    changeSinceSolstice,
   };
 };
 


### PR DESCRIPTION
## Summary
- rename Solar Flow card to SolarFlow and remove duplicated ZIP line
- drop icons in solar block and show daylight change since summer solstice
- compute daylight difference from summer solstice in utilities

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package eslint-plugin-react-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b2c63694832db3de02867d40d550