### PR TITLE
Remove extraneous solstice labels

### DIFF
--- a/src/components/SolarFlow.tsx
+++ b/src/components/SolarFlow.tsx
@@ -282,7 +282,7 @@ const SolarFlow: React.FC<SolarFlowProps> = ({ lat, lng, date }) => {
           whiteSpace: "normal",
         }}
       >
-        Summer<br />Solstice<br />(max)
+        Summer<br />Solstice
       </div>
       <div
         ref={equinoxRef}
@@ -298,7 +298,7 @@ const SolarFlow: React.FC<SolarFlowProps> = ({ lat, lng, date }) => {
           whiteSpace: "normal",
         }}
       >
-        Equinox<br />(~12h)
+        Equinox
       </div>
       <div
         ref={winterRef}
@@ -314,7 +314,7 @@ const SolarFlow: React.FC<SolarFlowProps> = ({ lat, lng, date }) => {
           whiteSpace: "normal",
         }}
       >
-        Winter<br />Solstice<br />(min)
+        Winter<br />Solstice
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Remove min/max/~12h annotations from SolarFlow guide labels

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest --no-save` *(fails: 403 Forbidden retrieving vitest)*
- `npm run lint` *(fails: cannot find eslint-plugin-react-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68a64f616004832dbfa8543705343068