### PR TITLE
Simplify equinox and winter labels

### DIFF
--- a/src/components/SolarFlow.tsx
+++ b/src/components/SolarFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect, useRef, useState } from "react";
+import React from "react";
 import {
   getSolarSeries,
   getCurrentDayIndexJuneShifted,
@@ -71,39 +71,6 @@ const SolarFlow: React.FC<SolarFlowProps> = ({ lat, lng, date }) => {
   const BOTTOM_PAD_PX = 26; // proportional bottom padding for cleaner spacing
   const LEFT_LABEL_COL_PX = 60; // Narrower label column stretches X-axis
   const RIGHT_PAD_PX = 8;
-
-  // Helper maps a Y in viewBox space → pixel offset within the container.
-  // Rounded to whole pixels for more precise alignment with grid lines.
-  const labelTop = useCallback(
-    (yView: number) =>
-      Math.round(
-        TOP_PAD_PX +
-          (yView / chartHeight) * (SVG_HEIGHT_PX - TOP_PAD_PX - BOTTOM_PAD_PX)
-      ),
-    [chartHeight]
-  ); // maps viewBox Y to pixel offset
-
-  const summerRef = useRef<HTMLDivElement>(null);
-  const equinoxRef = useRef<HTMLDivElement>(null);
-  const winterRef = useRef<HTMLDivElement>(null);
-  const [labelPos, setLabelPos] = useState({
-    summer: 0,
-    equinox: 0,
-    winter: 0,
-  });
-
-  useLayoutEffect(() => {
-    const calculateCenteredTop = (
-      y: number,
-      ref: React.RefObject<HTMLDivElement>
-    ) => labelTop(y) - (ref.current?.offsetHeight ?? 0) / 2;
-
-    setLabelPos({
-      summer: calculateCenteredTop(guideY.summer, summerRef),
-      equinox: calculateCenteredTop(guideY.equinox, equinoxRef),
-      winter: calculateCenteredTop(guideY.winter, winterRef),
-    });
-  }, [labelTop, guideY.summer, guideY.equinox, guideY.winter]);
 
   // Month ticks: June start → Sep (autumn) → Dec (winter) → Mar (spring) → next June
   const months = [
@@ -267,50 +234,51 @@ const SolarFlow: React.FC<SolarFlowProps> = ({ lat, lng, date }) => {
         ))}
       </div>
 
-      {/* Left-side guide labels (aligned with guide lines) */}
+      {/* Left-side guide labels (rough positioning) */}
       <div
-        ref={summerRef}
         style={{
           position: "absolute",
           left: 0,
-          top: labelPos.summer,
+          top: 0,
+          paddingLeft: 4,
           color: COL_TEXT_MUTE,
           width: LEFT_LABEL_COL_PX,
           fontSize: 7,
           lineHeight: 1.1,
-          textAlign: "center",
+          textAlign: "left",
           whiteSpace: "normal",
         }}
       >
         Summer<br />Solstice
       </div>
       <div
-        ref={equinoxRef}
         style={{
           position: "absolute",
           left: 0,
-          top: labelPos.equinox,
+          top: "50%",
+          paddingLeft: 4,
+          transform: "translateY(-50%)",
           color: COL_TEXT_MUTE,
           width: LEFT_LABEL_COL_PX,
           fontSize: 7,
           lineHeight: 1.1,
-          textAlign: "center",
+          textAlign: "left",
           whiteSpace: "normal",
         }}
       >
         Equinox
       </div>
       <div
-        ref={winterRef}
         style={{
           position: "absolute",
           left: 0,
-          top: labelPos.winter,
+          bottom: 0,
+          paddingLeft: 4,
           color: COL_TEXT_MUTE,
           width: LEFT_LABEL_COL_PX,
           fontSize: 7,
           lineHeight: 1.1,
-          textAlign: "center",
+          textAlign: "left",
           whiteSpace: "normal",
         }}
       >


### PR DESCRIPTION
## Summary
- Position equinox and winter solstice labels with simple absolute offsets
- Remove complex centering logic from SolarFlow component

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a655d743cc832dbd5e54289c40890e