### PR TITLE
Adjust solstice label position and change layout

### DIFF
--- a/src/components/SolarFlow.tsx
+++ b/src/components/SolarFlow.tsx
@@ -272,7 +272,7 @@ const SolarFlow: React.FC<SolarFlowProps> = ({ lat, lng, date }) => {
         style={{
           position: "absolute",
           left: 0,
-          bottom: 0,
+          bottom: 18,
           paddingLeft: 4,
           color: COL_TEXT_MUTE,
           width: LEFT_LABEL_COL_PX,

--- a/src/components/SolarInfo.tsx
+++ b/src/components/SolarInfo.tsx
@@ -45,7 +45,7 @@ const SolarInfo = ({ solarTimes, zipCode }: SolarInfoProps) => {
 
         {/* Change from Previous Day */}
         {solarTimes.changeFromPrevious && (
-          <div className="flex flex-col">
+          <div className="flex items-center justify-center gap-1">
             <span className="text-muted-foreground">Change</span>
             <span
               className={`font-semibold ${


### PR DESCRIPTION
## Summary
- show change metric inline with its label
- raise Winter Solstice label slightly above June marker

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a663834910832d8422e257a6c425ac