### PR TITLE
Center SolarFlow title and clarify solstice label

### DIFF
--- a/src/components/SolarInfo.tsx
+++ b/src/components/SolarInfo.tsx
@@ -64,7 +64,11 @@ const SolarInfo = ({ solarTimes, zipCode }: SolarInfoProps) => {
 
       {solarTimes.changeSinceSolstice && (
         <div className="mt-3 text-center text-[11px]">
-          <div className="text-muted-foreground">Since Jun 21 (Summer Solstice)</div>
+          <div className="text-muted-foreground">
+            Since June 21
+            <br />
+            (Summer Solstice)
+          </div>
           <div
             className={`font-semibold ${
               solarTimes.changeSinceSolstice.startsWith('-')

--- a/src/components/SunCard.tsx
+++ b/src/components/SunCard.tsx
@@ -32,7 +32,12 @@ const SunCard: React.FC<SunCardProps> = ({ lat, lng, date, zipCode }) => {
         boxShadow: "0 0 0 1px rgba(255,255,255,0.04) inset",
       }}
     >
-      <div style={{ padding: "2px 8px 10px 8px" }}>
+      <div
+        style={{
+          padding: "2px 8px 10px 8px",
+          textAlign: "center",
+        }}
+      >
         <div
           style={{
             fontSize: 20,


### PR DESCRIPTION
## Summary
- Split the solstice note onto its own line and spell out "June" in the label
- Center the SolarFlow heading within its card

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a67de4abd8832db4576c77df651c7c