### PR TITLE
feat: add dashboard back link to settings

### DIFF
--- a/src/components/settings/SettingsHeader.tsx
+++ b/src/components/settings/SettingsHeader.tsx
@@ -8,23 +8,20 @@ type SettingsHeaderProps = {
 };
 
 const SettingsHeader = ({ onBackPress }: SettingsHeaderProps) => {
-  const handleBackClick = () => {    onBackPress();
+  const handleBackClick = () => {
+    onBackPress();
   };
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between p-4 border-b border-gray-700 bg-background/90 backdrop-blur-sm shadow-md">
+    <div className="fixed top-0 left-0 right-0 z-50 p-4 border-b border-gray-700 bg-background/90 backdrop-blur-sm shadow-md flex flex-col items-center gap-2">
+      <h1 className="text-xl font-semibold text-white">Settings</h1>
       <Button
         variant="ghost"
-        size="icon"
         onClick={handleBackClick}
-        className="text-white hover:bg-gray-700"
+        className="text-white hover:bg-gray-700 flex items-center gap-1"
       >
-        <ArrowLeft className="h-6 w-6" />
+        <ArrowLeft className="h-4 w-4" /> Back to Dashboard
       </Button>
-      
-      <h1 className="text-xl font-semibold text-white">Settings</h1>
-      
-      <div className="w-10" /> {/* Spacer for centering */}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show "Back to Dashboard" below Settings title for easier navigation

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a70a7601f8832d92d1e91d85e7a22f