### PR TITLE
Optimize settings layout for complete display

### DIFF
--- a/src/components/settings/SettingsHeader.tsx
+++ b/src/components/settings/SettingsHeader.tsx
@@ -13,15 +13,15 @@ const SettingsHeader = ({ onBackPress }: SettingsHeaderProps) => {
   };
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-50 p-4 border-b border-gray-700 bg-background/90 backdrop-blur-sm shadow-md flex flex-col items-center gap-2">
-      <h1 className="text-xl font-semibold text-white">Settings</h1>
+    <div className="sticky top-0 z-50 flex items-center justify-center p-4 border-b border-gray-700 bg-background/90 backdrop-blur-sm shadow-md">
       <Button
         variant="ghost"
         onClick={handleBackClick}
-        className="text-white hover:bg-gray-700 flex items-center gap-1"
+        className="absolute left-4 text-white hover:bg-gray-700 flex items-center gap-1"
       >
         <ArrowLeft className="h-4 w-4" /> Back to Dashboard
       </Button>
+      <h1 className="text-xl font-semibold text-white">Settings</h1>
     </div>
   );
 };

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -9,28 +9,26 @@ import SettingsList from '@/components/settings/SettingsList';
 const Settings = () => {
   const navigate = useNavigate();
 
-  const handleBackPress = () => {    navigate('/');
+  const handleBackPress = () => {
+    navigate('/');
   };
 
   return (
-    <div className="min-h-screen pb-8 pt-16 relative overflow-y-auto">
+    <div className="relative h-screen flex flex-col">
       <StarsBackdrop />
-      
-      <div className="relative z-10">
-        <SettingsHeader onBackPress={handleBackPress} />
-        <div className="px-4 mt-6">
-          <SettingsList />
-          <div className="mt-12 text-center space-y-2">
-            <p className="text-sm text-gray-400">
-              For more information, detailed instructions, and the latest updates, visit our website.
-            </p>
-            <Button
-              variant="link"
-              onClick={() => window.open('https://moontide.site', '_blank')}
-            >
-              Visit moontide.site
-            </Button>
-          </div>
+      <SettingsHeader onBackPress={handleBackPress} />
+      <div className="flex-1 overflow-y-auto px-4 pt-6 pb-8 relative z-10">
+        <SettingsList />
+        <div className="mt-12 text-center space-y-2">
+          <p className="text-sm text-gray-400">
+            For more information, detailed instructions, and the latest updates, visit our website.
+          </p>
+          <Button
+            variant="link"
+            onClick={() => window.open('https://moontide.site', '_blank')}
+          >
+            Visit moontide.site
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- streamline Settings header with a single-row sticky layout and back button
- restructure Settings page to use flex layout so legal links remain visible

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7144430c8832da99317050ac460f8