### PR TITLE
Fix overlapping settings header and spacing

### DIFF
--- a/src/components/settings/SettingsHeader.tsx
+++ b/src/components/settings/SettingsHeader.tsx
@@ -13,15 +13,15 @@ const SettingsHeader = ({ onBackPress }: SettingsHeaderProps) => {
   };
 
   return (
-    <div className="sticky top-0 z-50 flex items-center justify-center p-4 border-b border-gray-700 bg-background/90 backdrop-blur-sm shadow-md">
+    <div className="sticky top-0 z-50 flex flex-col p-4 space-y-2 border-b border-gray-700 bg-background/90 backdrop-blur-sm shadow-md">
       <Button
         variant="ghost"
         onClick={handleBackClick}
-        className="absolute left-4 text-white hover:bg-gray-700 flex items-center gap-1"
+        className="self-start text-white hover:bg-gray-700 flex items-center gap-1"
       >
         <ArrowLeft className="h-4 w-4" /> Back to Dashboard
       </Button>
-      <h1 className="text-xl font-semibold text-white">Settings</h1>
+      <h1 className="w-full text-center text-xl font-semibold text-white">Settings</h1>
     </div>
   );
 };

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -17,9 +17,9 @@ const Settings = () => {
     <div className="relative h-screen flex flex-col">
       <StarsBackdrop />
       <SettingsHeader onBackPress={handleBackPress} />
-      <div className="flex-1 overflow-y-auto px-4 pt-6 pb-8 relative z-10">
+      <div className="flex-1 overflow-y-auto px-4 pt-6 pb-8 relative z-10 space-y-6">
         <SettingsList />
-        <div className="mt-12 text-center space-y-2">
+        <div className="text-center space-y-2">
           <p className="text-sm text-gray-400">
             For more information, detailed instructions, and the latest updates, visit our website.
           </p>


### PR DESCRIPTION
## Summary
- avoid header text overlap by stacking Back button and title
- add vertical spacing around settings list content

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a71c6ef51c832d95c3a537175940dc