### PR TITLE
Move website link into Settings action block

### DIFF
--- a/src/components/settings/SettingsList.tsx
+++ b/src/components/settings/SettingsList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import SettingsItem from './SettingsItem';
+import { Button } from '@/components/ui/button';
 import { FileText, Mail, Globe } from 'lucide-react';
 
 const SettingsList = () => {
@@ -41,6 +42,17 @@ const SettingsList = () => {
           )
         }
       />
+      <div className="p-4 text-center space-y-2">
+        <p className="text-sm text-gray-400">
+          For more information, detailed instructions, and the latest updates, visit our website.
+        </p>
+        <Button
+          variant="link"
+          onClick={() => window.open('https://moontide.site', '_blank')}
+        >
+          Visit moontide.site
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,6 @@
 
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
 import StarsBackdrop from '@/components/StarsBackdrop';
 import SettingsHeader from '@/components/settings/SettingsHeader';
 import SettingsList from '@/components/settings/SettingsList';
@@ -19,17 +18,6 @@ const Settings = () => {
       <SettingsHeader onBackPress={handleBackPress} />
       <div className="flex-1 overflow-y-auto px-4 pt-6 pb-8 relative z-10 space-y-6">
         <SettingsList />
-        <div className="text-center space-y-2">
-          <p className="text-sm text-gray-400">
-            For more information, detailed instructions, and the latest updates, visit our website.
-          </p>
-          <Button
-            variant="link"
-            onClick={() => window.open('https://moontide.site', '_blank')}
-          >
-            Visit moontide.site
-          </Button>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show "For more information..." message and link inside the Settings action block
- clean up Settings page now that the info link is inside the list

## Testing
- `npm run lint`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a725134138832db3d36363776daad1