### PR TITLE
Reorder Settings header back link

### DIFF
--- a/src/components/settings/SettingsHeader.tsx
+++ b/src/components/settings/SettingsHeader.tsx
@@ -14,6 +14,7 @@ const SettingsHeader = ({ onBackPress }: SettingsHeaderProps) => {
 
   return (
     <div className="sticky top-0 z-50 flex flex-col p-4 space-y-2 border-b border-gray-700 bg-background/90 backdrop-blur-sm shadow-md">
+      <h1 className="w-full text-center text-xl font-semibold text-white">Settings</h1>
       <Button
         variant="ghost"
         onClick={handleBackClick}
@@ -21,7 +22,6 @@ const SettingsHeader = ({ onBackPress }: SettingsHeaderProps) => {
       >
         <ArrowLeft className="h-4 w-4" /> Back to Dashboard
       </Button>
-      <h1 className="w-full text-center text-xl font-semibold text-white">Settings</h1>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- move "Back to Dashboard" link below "Settings" title

## Testing
- `npm test` *(fails: calculates moonrise/moonset assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68a72b12e2b4832d9faefa802ab0f2ac