### PR TITLE
Fix state filtering in saved locations

### DIFF
--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -120,13 +120,14 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
 
   const matchesState = (loc: LocationData | null): boolean => {
     if (!stateFilter) return true;
-    const state = (loc?.state || loc?.userSelectedState || '').toUpperCase();
+    const stationState = loc?.stationId ? stationStates[loc.stationId] : undefined;
+    const state = (stationState || loc?.state || loc?.userSelectedState || '').toUpperCase();
     return state === stateFilter.toUpperCase();
   };
 
   const stateFilteredHistory = useMemo(
     () => filteredHistory.filter((h) => matchesState(h)),
-    [filteredHistory, stateFilter],
+    [filteredHistory, stateFilter, stationStates],
   );
 
   const currentLocData = useMemo(


### PR DESCRIPTION
## Summary
- ensure saved-location state filtering uses station metadata instead of the user-selected state
- recompute filters when metadata loads

## Testing
- `npm test` *(fails: lunarUtils.test.ts compute moonrise/ moonset)*
- `npm run lint` *(fails: @typescript-eslint/no-unused-expressions cannot read property allowShortCircuit)*

------
https://chatgpt.com/codex/tasks/task_e_68a76b3d07a8832db144b98b9ac19a03