### PR TITLE
Fix state-based location filtering

### DIFF
--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -110,12 +110,20 @@ export default function LocationSelector({
     const history = locationStorage.getLocationHistory();
     const set = new Set<string>();
     favs.forEach((s) => set.add(s));
-    history.forEach((h) => h.state && set.add(h.state));
-    if (currentLocation?.state) set.add(currentLocation.state);
+    history.forEach((h) => {
+      if (h.userSelectedState) set.add(h.userSelectedState);
+      else if (h.state) set.add(h.state);
+    });
+
+    const currentState =
+      currentLocation?.userSelectedState ||
+      currentLocation?.cityState?.split(",").pop()?.trim();
+    if (currentState) set.add(currentState);
+
     const list = Array.from(set);
     setAvailableStates(list);
     if (!selectedState && list.length > 0) {
-      setSelectedState(currentLocation?.state || list[0]);
+      setSelectedState(currentState || list[0]);
     }
   }, [currentLocation, isOpen]);
 

--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -120,8 +120,15 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
 
   const matchesState = (loc: LocationData | null): boolean => {
     if (!stateFilter) return true;
-    const stationState = loc?.stationId ? stationStates[loc.stationId] : undefined;
-    const state = (stationState || loc?.state || loc?.userSelectedState || '').toUpperCase();
+    const state = (
+      loc?.userSelectedState ||
+      (loc?.stationId ? stationStates[loc.stationId] : undefined) ||
+      loc?.state ||
+      ''
+    )
+      .toString()
+      .trim()
+      .toUpperCase();
     return state === stateFilter.toUpperCase();
   };
 


### PR DESCRIPTION
## Summary
- include user-assigned states when building location filter options
- match saved locations against user-selected state before station metadata

## Testing
- `npm test` (fails: AssertionError in calculateMoonTimes)
- `npm run lint` (fails: TypeError reading 'allowShortCircuit')

------
https://chatgpt.com/codex/tasks/task_e_68a76f98f870832db18d0c17cc14f448