### PR TITLE
Expand location history list

### DIFF
--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -219,7 +219,7 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
       {stateFilteredHistory.length > 0 && (
         <div>
           <div className="text-xs font-medium text-muted-foreground mb-1">Location History</div>
-          <div className="space-y-2 max-h-40 overflow-y-auto">
+          <div className="space-y-2 max-h-60 overflow-y-auto">
             {stateFilteredHistory.map((location, index) => (
               <div
                 key={`${location.stationId}-${index}`}


### PR DESCRIPTION
## Summary
- Increase max height of location history list to show more stations

## Testing
- `npm test` *(fails: expected '2025-07-16T03:04:12' to be '2025-07-16T16:42:34')*
- `npm run lint` *(fails: cannot read property 'allowShortCircuit' of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a774de15e4832d8a1646e7b1cd44fd