### PR TITLE
fix: ensure location dropdown overlays content

### DIFF
--- a/src/components/LocationSelector.tsx
+++ b/src/components/LocationSelector.tsx
@@ -145,7 +145,8 @@ export default function LocationSelector({
         </button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent className="w-[90vw] max-w-md p-0 bg-background border shadow-lg z-50 sm:w-80">
+      {/* Ensure the location dropdown overlays all content like the "Next Phase" section */}
+      <DropdownMenuContent className="w-[90vw] max-w-md p-0 bg-background border shadow-lg z-[100] sm:w-80">
         <div className="p-4">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-sm font-medium">Select Location</h3>


### PR DESCRIPTION
## Summary
- elevate Change Tides dropdown above page content so "Next Phase" card no longer obscures it

## Testing
- `npm test` *(fails: expected moonrise time mismatch)*
- `npm run lint` *(fails: ESLint TypeError in @typescript-eslint/no-unused-expressions)*

------
https://chatgpt.com/codex/tasks/task_e_68a77a5db0bc832d86cd19441a043e5d