### PR TITLE
Allow full station names to wrap in saved locations

### DIFF
--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -198,7 +198,7 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
               <MapPin className="h-4 w-4 mt-0.5 text-primary" />
               <div className="flex-1 min-w-0">
                 <div className="flex items-center justify-between">
-                  <div className="font-medium text-sm truncate">
+                  <div className="font-medium text-xs sm:text-sm whitespace-normal leading-tight">
                     {getLocationDisplayName(currentLocData)}
                   </div>
                 </div>
@@ -230,7 +230,7 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
                   <MapPin className="h-4 w-4 mt-0.5 text-muted-foreground" />
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between">
-                      <div className="font-medium text-sm truncate">
+                      <div className="font-medium text-xs sm:text-sm whitespace-normal leading-tight">
                         {getLocationDisplayName(location)}
                       </div>
                       <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- prevent truncation of station names in SavedLocationsList
- allow multi-line display with smaller font for clarity

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined)*
- `npm test` *(fails: expected moonrise '2025-07-16T16:42:34' to be '2025-07-16T03:04:12')*

------
https://chatgpt.com/codex/tasks/task_e_68a783b358d8832dbd3f22e75042fc98