### PR TITLE
Sort stored stations alphabetically in location selector

### DIFF
--- a/src/components/SavedLocationsList.tsx
+++ b/src/components/SavedLocationsList.tsx
@@ -132,8 +132,25 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
     return state === stateFilter.toUpperCase();
   };
 
+  const getLocationDisplayName = (location: LocationData | null): string => {
+    if (!location) return 'Unknown Location';
+
+    if (location.nickname) return location.nickname;
+    if (location.stationName) return location.stationName;
+    return `${location.city}, ${location.state}`;
+  };
+
   const stateFilteredHistory = useMemo(
-    () => filteredHistory.filter((h) => matchesState(h)),
+    () =>
+      filteredHistory
+        .filter((h) => matchesState(h))
+        .sort((a, b) =>
+          getLocationDisplayName(a).localeCompare(
+            getLocationDisplayName(b),
+            undefined,
+            { sensitivity: 'base' },
+          ),
+        ),
     [filteredHistory, stateFilter, stationStates],
   );
 
@@ -155,14 +172,6 @@ export default function SavedLocationsList({ onLocationSelect, showEmpty = false
     if (hours > 0) return `${hours}h ago`;
     if (minutes > 0) return `${minutes}m ago`;
     return 'Just now';
-  };
-
-  const getLocationDisplayName = (location: LocationData | null): string => {
-    if (!location) return 'Unknown Location';
-
-    if (location.nickname) return location.nickname;
-    if (location.stationName) return location.stationName;
-    return `${location.city}, ${location.state}`;
   };
 
   const getLocationSubtext = (location: LocationData): string => {


### PR DESCRIPTION
## Summary
- sort saved station locations alphabetically for the Select Location dropdown

## Testing
- `npm test`
- `npm run lint` *(warn: Fast refresh only works when a file only exports components, React Hook missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a85f0fb594832dbf55adf222a42a6d