### PR TITLE
Add keystore reconstruction step to build workflow

### DIFF
--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -27,6 +27,11 @@ jobs:
 
       - name: Install Android SDK
         uses: android-actions/setup-android@v2
+        
+      - name: Reconstruct upload keystore
+        run: |
+          mkdir -p android/app
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/upload-keystore.jks
 
       - name: Build AAB
         run: npm run android:release


### PR DESCRIPTION
## Summary
- reconstruct upload keystore before running Gradle in the Build AAB workflow

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: repeated tar ENOENT warnings for node modules)*


------
https://chatgpt.com/codex/tasks/task_e_68aa5d10e84c832dbc2db7297cbd2bc2