### PR TITLE
chore: export android signing env

### DIFF
--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -33,6 +33,13 @@ jobs:
           mkdir -p android/app
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/upload-keystore.jks
 
+      - name: Export signing env
+        run: |
+          echo "ANDROID_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> $GITHUB_ENV
+          echo "ANDROID_KEYSTORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
+          echo "ANDROID_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}" >> $GITHUB_ENV
+          echo "ANDROID_KEYSTORE_PATH=$GITHUB_WORKSPACE/android/app/upload-keystore.jks" >> $GITHUB_ENV
+
       - name: Build AAB
         run: npm run android:release
 


### PR DESCRIPTION
## Summary
- export keystore signing env vars in Android AAB workflow

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest` *(fails: 403 Forbidden to registry)*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6e73eb98832d82c9944274b190fb