### PR TITLE
Configure Android release signing via environment variables

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,14 +24,18 @@ android {
     }
     signingConfigs {
         release {
-            if (keystorePropertiesFile.exists()) {
-                storeFile file(keystoreProperties['storeFile'])
-                storePassword keystoreProperties['storePassword']
-                keyAlias keystoreProperties['keyAlias']
-                keyPassword keystoreProperties['keyPassword']
+            def ksPath = System.getenv("ANDROID_KEYSTORE_PATH")
+            if (ksPath != null && new File(ksPath).exists()) {
+                storeFile file(ksPath)
+                storePassword System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias System.getenv("ANDROID_KEY_ALIAS")
+                keyPassword System.getenv("ANDROID_KEY_PASSWORD")
+            } else {
+                println("WARNING: ANDROID_KEYSTORE_PATH not set or file missing; release will be unsigned.")
             }
         }
     }
+
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
## Summary
- add release signing configuration based on environment variables

## Testing
- `cd android && ./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac761004f0832d87b9e53904176942