### PR TITLE
chore: add keystore debug step

### DIFF
--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -33,6 +33,15 @@ jobs:
           mkdir -p android/app
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/upload-keystore.jks
 
+      - name: Debug keystore presence
+        run: |
+          ls -lh android/app || true
+          if [ -s android/app/upload-keystore.jks ]; then
+            echo "Keystore OK"
+          else
+            echo "Keystore MISSING"; exit 1
+          fi
+
       - name: Export signing env
         run: |
           echo "ANDROID_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- add workflow step to confirm upload-keystore.jks exists and has content before signing

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_68ac88a7adb4832db1c075de64fc4996