### PR TITLE
Configure Android signing and release build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,7 @@ android {
         release {
             def ksPath = System.getenv("ANDROID_KEYSTORE_PATH")
             if (ksPath != null && new File(ksPath).exists()) {
+                println("Signing with keystore: " + ksPath)
                 storeFile file(ksPath)
                 storePassword System.getenv("ANDROID_KEYSTORE_PASSWORD")
                 keyAlias System.getenv("ANDROID_KEY_ALIAS")
@@ -38,6 +39,7 @@ android {
 
     buildTypes {
         release {
+            // keep existing release settings (minify, shrinker, proguard, etc.)
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release


### PR DESCRIPTION
## Summary
- ensure release build uses environment-based signing configuration
- document release build block for keeping existing settings

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ac9a926aa4832d90dda251e05be83b