### PR TITLE
Add signing report to Android AAB workflow

### DIFF
--- a/.github/workflows/build-aab.yml
+++ b/.github/workflows/build-aab.yml
@@ -49,8 +49,13 @@ jobs:
           echo "ANDROID_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}" >> $GITHUB_ENV
           echo "ANDROID_KEYSTORE_PATH=$GITHUB_WORKSPACE/android/app/upload-keystore.jks" >> $GITHUB_ENV
 
+      - name: Signing report
+        working-directory: android
+        run: ./gradlew :app:signingReport --no-daemon
+
       - name: Build AAB
-        run: npm run android:release
+        working-directory: android
+        run: ./gradlew clean :app:bundleRelease --no-daemon
 
       - name: Upload AAB as artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- generate signing report before building AAB
- build release bundle directly with Gradle

## Testing
- `npx vitest run`
- `npm run lint` *(fails: TypeError: Error while loading rule '@typescript-eslint/no-unused-expressions')*


------
https://chatgpt.com/codex/tasks/task_e_68ae069eca08832d838481ab1e5c983f