### PR TITLE
Remove Capacitor Cordova plugin references

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
 
 repositories {
     flatDir{
-        dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'
+        dirs 'libs'
     }
 }
 
@@ -61,7 +61,6 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation project(':capacitor-cordova-android-plugins')
 }
 
 apply from: 'capacitor.build.gradle'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,3 @@
 include ':app'
-include ':capacitor-cordova-android-plugins'
-project(':capacitor-cordova-android-plugins').projectDir = new File('./capacitor-cordova-android-plugins/')
 
 apply from: 'capacitor.settings.gradle'


### PR DESCRIPTION
## Summary
- remove Capacitor Cordova plugin dependency from app/build.gradle
- drop Capacitor Cordova include from settings.gradle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae2fe72ea0832d8df79d1d5f9b17f9