### PR TITLE
chore(android): update kotlin stdlib to 1.9.25

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.25"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,16 @@ allprojects {
         google()
         mavenCentral()
     }
+    configurations.all {
+        resolutionStrategy {
+            eachDependency { details ->
+                if (details.requested.group == 'org.jetbrains.kotlin') {
+                    details.useVersion '1.9.25'
+                    details.because 'Force Kotlin stdlib version 1.9.25'
+                }
+            }
+        }
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
## Summary
- ensure app module explicitly depends on Kotlin stdlib 1.9.25
- force all Kotlin dependencies to resolve to 1.9.25

## Testing
- `cd android && ./gradlew tasks --all` *(fails: Could not resolve com.android.tools.build:gradle:8.7.2, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c20e7e78832dacc6a72f05cdd6ea