### PR TITLE
chore: use Vite build output for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 dist/
 android/app/build/
+android/app/src/main/assets/*
+!android/app/src/main/assets/.keep
 
 # Keystore file - contains sensitive credentials
 keystore.jks

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",
+    "build:android": "npm run build && rm -rf android/app/src/main/assets/* && cp -r dist/* android/app/src/main/assets/",
     "lint": "eslint .",
     "preview": "vite preview",
-    "android:debug": "npm run build && cd android && ./gradlew assembleDebug",
+    "android:debug": "npm run build:android && cd android && ./gradlew assembleDebug",
     "android:release": "npm run build && cd android && ./gradlew bundleRelease",
     "test": "vitest"
   },


### PR DESCRIPTION
## Summary
- ignore Vite build output and Android assets
- add `build:android` script to copy Vite dist files into Android assets
- invoke `build:android` when running `android:debug`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f51f15f4832dab0b001d53608198