### PR TITLE
chore(android): use Kotlin 1.9.25

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -51,17 +51,18 @@ repositories {
     }
 }
 
-dependencies {
-    implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
-    implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
-    implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
-    implementation project(':capacitor-android')
-    testImplementation "junit:junit:$junitVersion"
-    androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
-    androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation project(':capacitor-cordova-android-plugins')
-}
+  dependencies {
+      implementation fileTree(include: ['*.jar'], dir: 'libs')
+      implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+      implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
+      implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+      implementation project(':capacitor-android')
+      implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.25"
+      testImplementation "junit:junit:$junitVersion"
+      androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
+      androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
+      implementation project(':capacitor-cordova-android-plugins')
+  }
 
 apply from: 'capacitor.build.gradle'
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,15 @@ allprojects {
         google()
         mavenCentral()
     }
+    configurations.all {
+        resolutionStrategy {
+            eachDependency { details ->
+                if (details.requested.group == 'org.jetbrains.kotlin') {
+                    details.useVersion '1.9.25'
+                }
+            }
+        }
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
## Summary
- add Kotlin stdlib 1.9.25 dependency to app module
- enforce Kotlin 1.9.25 for all Kotlin artifacts via resolution strategy

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c34c77e0832dbe14b3e9174da25c