### PR TITLE
Fix full and new moon display in 7-day forecast

### DIFF
--- a/src/utils/lunarUtils.ts
+++ b/src/utils/lunarUtils.ts
@@ -69,10 +69,15 @@ export const findMostRecentNewMoon = (date: Date): Date => {
 
 // More accurate moon phase calculation using a known lunar cycle reference
 
-export const calculateMoonPhase = (date: Date): { phase: string; illumination: number } => {
-  // For full moon, check against the exact date from ephemeris for accuracy
+export const calculateMoonPhase = (
+  date: Date
+): { phase: string; illumination: number } => {
+  // For full/new moon, check against the exact date from ephemeris for accuracy
   if (isDateFullMoon(date)) {
     return { phase: "Full Moon", illumination: 100 };
+  }
+  if (isDateNewMoon(date)) {
+    return { phase: "New Moon", illumination: 0 };
   }
 
   const MS_PER_DAY = 1000 * 60 * 60 * 24;
@@ -96,16 +101,14 @@ export const calculateMoonPhase = (date: Date): { phase: string; illumination: n
   // Determine phase with refined waning boundaries
   let phase: string;
 
-  if (cyclePosition < 0.0625) {
-    phase = "New Moon";
-  } else if (cyclePosition < 0.1875) {
+  if (cyclePosition < 0.1875) {
     phase = "Waxing Crescent";
   } else if (cyclePosition < 0.3125) {
     phase = "First Quarter";
-  } else if (cyclePosition < 0.4375) {
+  } else if (cyclePosition < 0.5) {
     phase = "Waxing Gibbous";
   } else if (cyclePosition < 0.5625) {
-    phase = "Full Moon";
+    phase = "Waning Gibbous";
   } else {
     const isWaning = cyclePosition >= 0.5;
     const nearLastQuarter = Math.abs(cyclePosition - 0.75) <= 0.01;

--- a/tests/lunarUtils.test.ts
+++ b/tests/lunarUtils.test.ts
@@ -51,3 +51,19 @@ describe('calculateMoonPhase with full moon fix', () => {
     expect(result.phase).toBe('Waxing Gibbous');
   });
 });
+
+describe('calculateMoonPhase with new moon fix', () => {
+  it('correctly identifies a new moon on the exact date', () => {
+    const date = parseIsoAsLocal('2025-09-22T00:00:00');
+    const result = calculateMoonPhase(date);
+    expect(result.phase).toBe('New Moon');
+    expect(result.illumination).toBe(0);
+  });
+
+  it('does not identify the day after a new moon as a new moon', () => {
+    const date = parseIsoAsLocal('2025-09-23T00:00:00');
+    const result = calculateMoonPhase(date);
+    expect(result.phase).not.toBe('New Moon');
+    expect(result.phase).toBe('Waxing Crescent');
+  });
+});


### PR DESCRIPTION
## Summary
- prevent algorithm from labeling multiple days as full or new moon
- add ephemeris-based check for new moon and refine phase thresholds
- expand tests to ensure only the correct date is tagged as full or new moon

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b711736668832d9e05723c1aa8b7b0