### PR TITLE
fix: ensure integer versionCode

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,29 +4,26 @@ import java.io.FileOutputStream
 
 apply plugin: 'com.android.application'
 
-int getVersionCode() {
-    def versionPropsFile = new File(rootProject.projectDir, 'version.properties')
-    Properties versionProps = new Properties()
-    int code
+def versionPropsFile = new File(rootProject.projectDir, 'version.properties')
+Properties versionProps = new Properties()
+int computedVersionCode = 1
 
-    if (versionPropsFile.exists()) {
-        versionProps.load(new FileInputStream(versionPropsFile))
-        code = versionProps['VERSION_CODE'].toInteger()
-    } else {
-        code = 2
-        versionProps['VERSION_CODE'] = code.toString()
-        versionProps.store(new FileOutputStream(versionPropsFile), null)
-    }
-
-    if (gradle.startParameter.taskNames.any { it.toLowerCase().contains('release') } && !project.hasProperty('versionCodeIncremented')) {
-        code++
-        versionProps['VERSION_CODE'] = code.toString()
-        versionProps.store(new FileOutputStream(versionPropsFile), null)
-        project.ext.versionCodeIncremented = true
-    }
-
-    return code
+if (versionPropsFile.exists()) {
+    versionProps.load(new FileInputStream(versionPropsFile))
+    computedVersionCode = versionProps['VERSION_CODE'].toInteger()
 }
+
+if (gradle.startParameter.taskNames.any { it.toLowerCase().contains('release') }) {
+    computedVersionCode++
+    versionProps['VERSION_CODE'] = computedVersionCode.toString()
+    versionProps.store(new FileOutputStream(versionPropsFile), null)
+}
+
+int getVersionCode() {
+    return computedVersionCode
+}
+
+ext.versionCode = computedVersionCode
 
 android {
     def keystorePropertiesFile = rootProject.file('keystore.properties')
@@ -41,7 +38,7 @@ android {
         applicationId "com.slicktimesavers.moontide"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode = getVersionCode()
+        versionCode getVersionCode()
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {


### PR DESCRIPTION
## Summary
- read and increment version code from version.properties for release builds
- expose computed versionCode to Gradle and set defaultConfig with a pure getter

## Testing
- `./gradlew :app:properties | grep version`

------
https://chatgpt.com/codex/tasks/task_e_68b8aaa6fbcc832dafb5b8073c4e0400