### PR TITLE
feat: build android artifacts on main push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Production
+name: Build Android Artifacts
 
 on:
   push:
@@ -7,46 +7,57 @@ on:
 
 jobs:
   build:
-    name: Build Web App
     runs-on: ubuntu-latest
 
     steps:
-      # 1) Check out source
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # 2) Set up Node 20
-      - name: Set up Node 20
-        uses: actions/setup-node@v3
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 20
 
-      # 3) Install dependencies
-      - name: Install deps
+      - name: Install dependencies
         run: npm ci
 
-      # 4) Build production
-      - name: Build production
+      - name: Build web assets
         run: npm run build
 
-      # 5) Set up JDK for Android build
-      - name: Set up JDK 21
+      - name: Sync Capacitor assets
+        run: npx cap copy && npx cap sync android
+
+      - name: Set up Java 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
-      # 6) Set up Android SDK
       - name: Set up Android SDK
         uses: android-actions/setup-android@v2
 
-      # 7) Build Android debug APK
-      - name: Build Android APK
-        run: npm run android:debug
+      - name: Reconstruct upload keystore
+        run: |
+          mkdir -p android/app
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/upload-keystore.jks
 
-      # 8) Upload debug APK artifact
-      - name: Upload app-debug.apk
+      - name: Build Android artifacts
+        working-directory: android
+        env:
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/android/app/upload-keystore.jks
+        run: ./gradlew assembleDebug bundleRelease
+
+      - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:
           name: app-debug.apk
           path: android/app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Upload release AAB
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release.aab
+          path: android/app/build/outputs/bundle/release/app-release.aab

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,33 @@
+import java.util.Properties
+import java.io.FileInputStream
+import java.io.FileOutputStream
+
 apply plugin: 'com.android.application'
+
+def versionPropsFile = new File(rootProject.projectDir, 'version.properties')
+Properties versionProps = new Properties()
+int computedVersionCode = 1
+
+if (versionPropsFile.exists()) {
+    versionProps.load(new FileInputStream(versionPropsFile))
+    computedVersionCode = versionProps['VERSION_CODE'].toInteger()
+}
+
+if (gradle.startParameter.taskNames.any { it.toLowerCase().contains('release') }) {
+    computedVersionCode++
+    versionProps['VERSION_CODE'] = computedVersionCode.toString()
+    versionProps.store(new FileOutputStream(versionPropsFile), null)
+}
+
+int getVersionCode() {
+    return computedVersionCode
+}
+
+String getVersionName() {
+    return "1.0.${computedVersionCode}"
+}
+
+ext.versionCode = computedVersionCode
 
 android {
     def keystorePropertiesFile = rootProject.file('keystore.properties')
@@ -13,8 +42,8 @@ android {
         applicationId "com.slicktimesavers.moontide"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 2
-        versionName "1.0.${versionCode}"
+        versionCode getVersionCode()
+        versionName getVersionName()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.


### PR DESCRIPTION
## Summary
- Build web assets and Android debug APK and release AAB on pushes to main
- Sync Capacitor assets, configure Java and Android SDK, and upload build artifacts
- Reinstate Android version auto-increment logic for versionCode and versionName

## Testing
- `npm test`
- `./gradlew tasks`


------
https://chatgpt.com/codex/tasks/task_e_68bb062ea374832d9c82fea8fbe5d445