### PR TITLE
chore: streamline Android build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build Android Artifacts
@@ -54,13 +57,7 @@ jobs:
           mkdir -p android/app
           echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/upload-keystore.jks
 
-      # 9) Print version for debugging
-      - name: Print version for debugging
-        run: |
-          echo "Contents of android/version.properties:"
-          cat android/version.properties
-
-      # 10) Build Android debug APK
+      # 9) Build Android debug APK
       - name: Build Android APK (debug)
         run: npm run android:debug
 


### PR DESCRIPTION
## Summary
- streamline Android build workflow by removing debug-only version print step
- version bump script updates `android/version.properties` read by Gradle
- grant workflow `contents: write` permission so version bumps can push back

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bc5686fa8c832da2181968dc1991b0