### PR TITLE
feat(settings): display dynamic app version

### DIFF
--- a/src/components/settings/SettingsHeader.tsx
+++ b/src/components/settings/SettingsHeader.tsx
@@ -5,9 +5,10 @@ import { Button } from '@/components/ui/button';
 
 type SettingsHeaderProps = {
   onBackPress: () => void;
+  appVersion: string;
 };
 
-const SettingsHeader = ({ onBackPress }: SettingsHeaderProps) => {
+const SettingsHeader = ({ onBackPress, appVersion }: SettingsHeaderProps) => {
   const handleBackClick = () => {
     onBackPress();
   };
@@ -15,6 +16,7 @@ const SettingsHeader = ({ onBackPress }: SettingsHeaderProps) => {
   return (
     <div className="sticky top-0 z-50 flex flex-col p-4 space-y-2 border-b border-gray-700 bg-background/90 backdrop-blur-sm shadow-md">
       <h1 className="w-full text-center text-xl font-semibold text-white">Settings</h1>
+      <p className="w-full text-center text-sm text-gray-400">Version {appVersion}</p>
       <Button
         variant="ghost"
         onClick={handleBackClick}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -4,6 +4,10 @@ import { useNavigate } from 'react-router-dom';
 import StarsBackdrop from '@/components/StarsBackdrop';
 import SettingsHeader from '@/components/settings/SettingsHeader';
 import SettingsList from '@/components/settings/SettingsList';
+import versionFile from '../../android/version.properties?raw';
+
+const match = versionFile.match(/VERSION_CODE=(\d+)/);
+const appVersion = `1.0.${match ? Number(match[1]) + 1 : 1}`;
 
 const Settings = () => {
   const navigate = useNavigate();
@@ -15,7 +19,7 @@ const Settings = () => {
   return (
     <div className="relative h-screen flex flex-col">
       <StarsBackdrop />
-      <SettingsHeader onBackPress={handleBackPress} />
+      <SettingsHeader onBackPress={handleBackPress} appVersion={appVersion} />
       <div className="flex-1 overflow-y-auto px-4 pt-6 pb-8 relative z-10 space-y-6">
         <SettingsList />
       </div>


### PR DESCRIPTION
## Summary
- display auto-incrementing app version in Settings header

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_68bc79f80988832da1a07e631bdae706