### PR TITLE
Use VERSION_CODE directly in settings

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,7 +7,7 @@ import SettingsList from '@/components/settings/SettingsList';
 import versionFile from '../../android/version.properties?raw';
 
 const match = versionFile.match(/VERSION_CODE=(\d+)/);
-const appVersion = `1.0.${match ? Number(match[1]) + 1 : 1}`;
+const appVersion = `1.0.${match ? Number(match[1]) : 1}`;
 
 const Settings = () => {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- display the VERSION_CODE on the Settings page without incrementing it

## Testing
- `npm test`
- `npm run lint` *(fails: TypeError: Error while loading rule '@typescript-eslint/no-unused-expressions')*


------
https://chatgpt.com/codex/tasks/task_e_68bc87cc1534832d8ecc82f8eb63c0b6