### PR TITLE
Display upcoming lunar and solar events

### DIFF
--- a/src/components/MoonData.tsx
+++ b/src/components/MoonData.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { formatIsoToAmPm } from '@/utils/dateTimeUtils';
-import { getFullMoonName } from '@/utils/lunarUtils';
-import { FULL_MOON_DATES_UTC } from '@/utils/moonEphemeris';
+import { getFullMoonName, findNextFullMoon, findNextNewMoon } from '@/utils/lunarUtils';
 
 type MoonDataProps = {
   illumination: number;
@@ -9,34 +8,32 @@ type MoonDataProps = {
   moonset: string;
 };
 
-const findNextFullMoon = (currentDate: Date) => {
-  const now = currentDate.getTime();
-  for (const dateStr of FULL_MOON_DATES_UTC) {
-    const fullMoon = new Date(`${dateStr}T00:00:00Z`);
-    if (fullMoon.getTime() > now) {
-      return fullMoon;
-    }
-  }
-  return null;
-};
-
 const MoonData = ({ illumination, moonrise, moonset }: MoonDataProps) => {
   const nextFullMoonDate = React.useMemo(() => findNextFullMoon(new Date()), []);
+  const nextNewMoonDate = React.useMemo(() => findNextNewMoon(new Date()), []);
 
-  let nextPhaseInfo = "Not available";
+  let nextFullInfo = "Not available";
   if (nextFullMoonDate) {
-    // Use UTC for an accurate day difference calculation
     const now = new Date();
     const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
     const daysUntil = Math.round((nextFullMoonDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
     const fullMoonName = getFullMoonName(nextFullMoonDate)?.name || "Full Moon";
+    if (daysUntil === 0) {
+      nextFullInfo = `${fullMoonName} today`;
+    } else if (daysUntil > 0) {
+      nextFullInfo = `${fullMoonName} in ${daysUntil} day${daysUntil !== 1 ? 's' : ''}`;
+    }
+  }
 
-    if (daysUntil >= 0) {
-        if (daysUntil === 0) {
-            nextPhaseInfo = `${fullMoonName} today`;
-        } else {
-            nextPhaseInfo = `${fullMoonName} in ${daysUntil} day${daysUntil !== 1 ? 's' : ''}`;
-        }
+  let nextNewInfo = "Not available";
+  if (nextNewMoonDate) {
+    const now = new Date();
+    const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const daysUntil = Math.round((nextNewMoonDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+    if (daysUntil === 0) {
+      nextNewInfo = "New Moon today";
+    } else if (daysUntil > 0) {
+      nextNewInfo = `New Moon in ${daysUntil} day${daysUntil !== 1 ? 's' : ''}`;
     }
   }
 
@@ -55,8 +52,12 @@ const MoonData = ({ illumination, moonrise, moonset }: MoonDataProps) => {
         <span className="font-semibold">{formatIsoToAmPm(moonset)}</span>
       </div>
       <div className="flex flex-col items-center py-1">
-        <span className="text-muted-foreground">Next Phase</span>
-        <span className="font-semibold">{nextPhaseInfo}</span>
+        <span className="text-muted-foreground">Next Full Moon</span>
+        <span className="font-semibold">{nextFullInfo}</span>
+      </div>
+      <div className="flex flex-col items-center py-1">
+        <span className="text-muted-foreground">Next New Moon</span>
+        <span className="font-semibold">{nextNewInfo}</span>
       </div>
     </div>
   );

--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { getFullMoonName, isFullMoon, calculateMoonPhase } from '@/utils/lunarUtils';
-import { getSolarEvents } from '@/utils/solarUtils';
 import FullMoonBanner from './FullMoonBanner';
 import MoonVisual from './MoonVisual';
 import MoonData from './MoonData';
@@ -59,8 +58,6 @@ const MoonPhase = ({
   const lat = currentLocation?.lat ?? 41.4353; // Default to Newport, RI
   const lng = currentLocation?.lng ?? -71.4616;
 
-  const solarEvent = getSolarEvents(currentDate);
-
   return (
     <div className="w-full">
       <Card className={cn("overflow-hidden bg-card/50 backdrop-blur-md", className)}>
@@ -82,7 +79,7 @@ const MoonPhase = ({
 
           <div className="border-t border-muted pt-4 w-full space-y-4">
             <SunCard lat={lat} lng={lng} date={currentDate} zipCode={currentLocation?.zipCode} />
-            {solarEvent && <SolarEventInfo selectedDate={currentDate} />}
+            <SolarEventInfo selectedDate={currentDate} />
           </div>
         </CardContent>
       </Card>

--- a/src/components/WeeklyForecast.tsx
+++ b/src/components/WeeklyForecast.tsx
@@ -6,7 +6,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Info } from "lucide-react";
 import LocationDisplay from './LocationDisplay';
 import { SavedLocation } from './LocationSelector';
-import { getFullMoonName, isFullMoon } from '@/utils/lunarUtils';
+import { getFullMoonName, isFullMoon, isDateNewMoon } from '@/utils/lunarUtils';
+import { getSolarEvents } from '@/utils/solarUtils';
 import { formatApiDate, formatIsoToAmPm } from '@/utils/dateTimeUtils';
 import { TideCycle } from '@/services/tide/types';
 import { Badge } from "@/components/ui/badge";
@@ -132,10 +133,12 @@ const WeeklyForecast = ({
             </div>
           ) : (
             forecast.map((day, index) => {
-              // Parse the date to get full moon name if applicable
+              // Parse the date to get lunar and solar events
               const dayDate = new Date(formatApiDate(day.date));
               const fullMoonName = isFullMoon(day.moonPhase) ? getFullMoonName(dayDate) : null;
-              
+              const isNewMoonDay = isDateNewMoon(dayDate);
+              const solarEvent = getSolarEvents(dayDate);
+
               return (
                 <div
                   key={index}
@@ -158,13 +161,16 @@ const WeeklyForecast = ({
                     <div className={`w-8 h-8 rounded-full ${getMoonPhaseVisual(day.moonPhase)}`}></div>
                     <div className="flex-1">
                       <p className="text-xs text-muted-foreground">Moon Phase</p>
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className={`text-sm ${isNewMoonDay || fullMoonName ? 'text-yellow-400 font-medium' : ''}`}>
                           {day.moonPhase}
-                          {fullMoonName && (
-                            <span className="text-yellow-400 font-medium"> – {fullMoonName.name}</span>
-                          )}
+                          {fullMoonName && ` – ${fullMoonName.name}`}
                         </span>
+                        {solarEvent && (
+                          <Badge variant="outline" className="bg-orange-500/20 text-orange-100 border-orange-500/30">
+                            {solarEvent.name}
+                          </Badge>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/src/components/fishing/SolarEventInfo.tsx
+++ b/src/components/fishing/SolarEventInfo.tsx
@@ -1,23 +1,28 @@
 
 import React from 'react';
-import { getSolarEvents } from '@/utils/solarUtils';
+import { findNextSolarEvent } from '@/utils/solarUtils';
 
 type SolarEventInfoProps = {
   selectedDate: Date;
 };
 
 const SolarEventInfo: React.FC<SolarEventInfoProps> = ({ selectedDate }) => {
-  const solarEvent = getSolarEvents(selectedDate);
-  
-  if (!solarEvent) return null;
+  const nextEvent = React.useMemo(() => findNextSolarEvent(selectedDate), [selectedDate]);
+
+  if (!nextEvent) return null;
+
+  const { event, date } = nextEvent;
+  const today = new Date(selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate());
+  const daysUntil = Math.round((date.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+  const whenText = daysUntil === 0 ? 'today' : `in ${daysUntil} day${daysUntil !== 1 ? 's' : ''}`;
 
   return (
     <div className="p-4 rounded-md bg-orange-500/10 border border-orange-500/20">
       <div className="flex items-center gap-2 mb-2">
-        <span className="text-2xl">{solarEvent.emoji}</span>
-        <h3 className="text-lg font-medium text-orange-100">{solarEvent.name}</h3>
+        <span className="text-2xl">{event.emoji}</span>
+        <h3 className="text-lg font-medium text-orange-100">{event.name} {whenText}</h3>
       </div>
-      <p className="text-orange-200">{solarEvent.description}</p>
+      <p className="text-orange-200">{event.description}</p>
     </div>
   );
 };

--- a/src/utils/lunarUtils.ts
+++ b/src/utils/lunarUtils.ts
@@ -67,6 +67,30 @@ export const findMostRecentNewMoon = (date: Date): Date => {
   return new Date(`${NEW_MOON_DATES_UTC[0]}T00:00:00Z`);
 };
 
+// Find the next full moon after the given date
+export const findNextFullMoon = (currentDate: Date): Date | null => {
+  const now = currentDate.getTime();
+  for (const dateStr of FULL_MOON_DATES_UTC) {
+    const fullMoon = new Date(`${dateStr}T00:00:00Z`);
+    if (fullMoon.getTime() > now) {
+      return fullMoon;
+    }
+  }
+  return null;
+};
+
+// Find the next new moon after the given date
+export const findNextNewMoon = (currentDate: Date): Date | null => {
+  const now = currentDate.getTime();
+  for (const dateStr of NEW_MOON_DATES_UTC) {
+    const newMoon = new Date(`${dateStr}T00:00:00Z`);
+    if (newMoon.getTime() > now) {
+      return newMoon;
+    }
+  }
+  return null;
+};
+
 // More accurate moon phase calculation using a known lunar cycle reference
 
 export const calculateMoonPhase = (
@@ -127,7 +151,7 @@ export const calculateMoonPhase = (
 };
 
 import { formatDateTimeAsLocalIso } from "./dateTimeUtils";
-import { FULL_MOON_SET, NEW_MOON_SET, NEW_MOON_DATES_UTC } from "./moonEphemeris";
+import { FULL_MOON_SET, FULL_MOON_DATES_UTC, NEW_MOON_SET, NEW_MOON_DATES_UTC } from "./moonEphemeris";
 
 // Replace isDateFullMoon and isDateNewMoon with accurate table lookups
 /**

--- a/src/utils/solarUtils.ts
+++ b/src/utils/solarUtils.ts
@@ -177,3 +177,18 @@ export const getSolarEvents = (date: Date): SolarEvent | null => {
 
   return null;
 };
+
+// Find the next solar event after the given date
+export const findNextSolarEvent = (
+  date: Date
+): { event: SolarEvent; date: Date } | null => {
+  for (let i = 0; i < 365 * 3; i++) {
+    const next = new Date(date);
+    next.setDate(next.getDate() + i);
+    const event = getSolarEvents(next);
+    if (event) {
+      return { event, date: next };
+    }
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary
- show next full and new moon with countdown on the splash card
- highlight upcoming equinox/solstice with orange countdown banner
- mark new moons and solar events in the 7‑day forecast

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be999fdc78832dbc5f9efe8770d2ee