### PR TITLE
Reorder solar event on splash screen

### DIFF
--- a/src/components/MoonPhase.tsx
+++ b/src/components/MoonPhase.tsx
@@ -77,9 +77,10 @@ const MoonPhase = ({
             moonset={moonset}
           />
 
-          <div className="border-t border-muted pt-4 w-full space-y-4">
+          <SolarEventInfo selectedDate={currentDate} />
+
+          <div className="border-t border-muted pt-4 w-full">
             <SunCard lat={lat} lng={lng} date={currentDate} zipCode={currentLocation?.zipCode} />
-            <SolarEventInfo selectedDate={currentDate} />
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- Move next solar event display above SolarFlow chart on splash screen

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_68bea94247b8832dab835f34d37c4962