### PR TITLE
fix: prevent SolarEventInfo text from wrapping

### DIFF
--- a/src/components/fishing/SolarEventInfo.tsx
+++ b/src/components/fishing/SolarEventInfo.tsx
@@ -17,12 +17,12 @@ const SolarEventInfo: React.FC<SolarEventInfoProps> = ({ selectedDate }) => {
   const whenText = daysUntil === 0 ? 'today' : `in ${daysUntil} day${daysUntil !== 1 ? 's' : ''}`;
 
   return (
-    <div className="p-4 rounded-md bg-orange-500/10 border border-orange-500/20">
+    <div className="p-4 rounded-md bg-orange-500/10 border border-orange-500/20 w-full max-w-sm">
       <div className="flex items-center gap-2 mb-2">
         <span className="text-2xl">{event.emoji}</span>
-        <h3 className="text-lg font-medium text-orange-100">{event.name} {whenText}</h3>
+        <h3 className="text-lg font-medium text-orange-100 truncate flex-1">{event.name} {whenText}</h3>
       </div>
-      <p className="text-orange-200">{event.description}</p>
+      <p className="text-orange-200 truncate">{event.description}</p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add max width to SolarEventInfo card to keep width consistent
- truncate title and description so they don't wrap

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*
- `npm run build` *(fails: Failed to resolve entry for package "lovable-tagger")*

------
https://chatgpt.com/codex/tasks/task_e_68becb9de084832d81074a3ca4c82cd5