### PR TITLE
fix: wrap text in SolarEventInfo card

### DIFF
--- a/src/components/fishing/SolarEventInfo.tsx
+++ b/src/components/fishing/SolarEventInfo.tsx
@@ -18,11 +18,11 @@ const SolarEventInfo: React.FC<SolarEventInfoProps> = ({ selectedDate }) => {
 
   return (
     <div className="p-4 rounded-md bg-orange-500/10 border border-orange-500/20 w-full max-w-sm">
-      <div className="flex items-center gap-2 mb-2">
+      <div className="flex items-start gap-2 mb-2">
         <span className="text-2xl">{event.emoji}</span>
-        <h3 className="text-lg font-medium text-orange-100 truncate flex-1">{event.name} {whenText}</h3>
+        <h3 className="text-base font-medium text-orange-100 leading-tight flex-1">{event.name} {whenText}</h3>
       </div>
-      <p className="text-orange-200 truncate">{event.description}</p>
+      <p className="text-sm text-orange-200 leading-tight mt-1">{event.description}</p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- allow SolarEventInfo card heading and description to wrap and reduce text sizes

## Testing
- `CI=1 npm test`
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_68bedcfca2f8832d91c52da87b377ea5